### PR TITLE
Add AICoE yaml for CI image build

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -1,14 +1,15 @@
 # Setup and configuring aicoe-ci with configuration file `.aicoe-ci.yaml`
 # Example `.aicoe-ci.yaml` with a full list of config options is available here: https://github.com/AICoE/aicoe-ci/blob/master/docs/.aicoe-ci.yaml
 check:
-  # Uncomment following line to build a public image of this repo
-  # - thoth-build
-# Uncomment following lines to build a public image of this repo
-# build:
-#   build-stratergy: Source
-#   build-source-script: "image:///opt/app-root/builder"
-#   base-image: quay.io/thoth-station/s2i-custom-notebook:latest
-#   registry: quay.io
-#   registry-org: aicoe
-#   registry-project: <CHANGE-ME>
-#   registry-secret: aicoe-pusher-secret
+  - thoth-precommit
+  - thoth-build
+
+build:
+  build-stratergy: Source
+  build-source-script: "image:///opt/app-root/builder"
+  base-image: quay.io/thoth-station/s2i-elyra-custom-notebook:latest
+  custom-tag: latest
+  registry: quay.io
+  registry-org: aicoe
+  registry-project: operate-first-jupyterhub-analysis
+  registry-secret: aicoe-pusher-secret


### PR DESCRIPTION
Related issue #20 
This PR updates .aicoe-ci.yaml file for the AICoE CI pipeline to automatically build the container image and push it to quay. 